### PR TITLE
Disable saving of backlight state  to efi to allow compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ As root, do the following (all MacBook's and MacBook Pro's except MacBook8,1 (20
 echo -e "\n# applespi\napplespi\nspi_pxa2xx_platform\nintel_lpss_pci" >> /etc/initramfs-tools/modules
 
 apt install dkms
-git clone https://github.com/PatrickVerner/macbook12-spi-driver.git /usr/src/applespi-0.1
+git clone https://github.com/marc-git/macbook12-spi-driver.git /usr/src/applespi-0.1
 dkms install -m applespi -v 0.1
 ```
 
@@ -34,7 +34,7 @@ If you're on a MacBook8,1 (2015):
 echo -e "\n# applespi\napplespi\nspi_pxa2xx_platform\nspi_pxa2xx_pci" >> /etc/initramfs-tools/modules
 
 apt install dkms
-git clone https://github.com/PatrickVerner/macbook12-spi-driver.git /usr/src/applespi-0.1
+git clone https://github.com/marc-git/macbook12-spi-driver.git /usr/src/applespi-0.1
 dkms install -m applespi -v 0.1
 ```
 

--- a/applespi.c
+++ b/applespi.c
@@ -1802,7 +1802,7 @@ static u32 applespi_notify(acpi_handle gpe_device, u32 gpe, void *context)
 
 static int applespi_get_saved_bl_level(struct applespi_data *applespi)
 {
-	struct efivar_entry *efivar_entry;
+	/*struct efivar_entry *efivar_entry;
 	u16 efi_data = 0;
 	unsigned long efi_data_len;
 	int sts;
@@ -1824,19 +1824,20 @@ static int applespi_get_saved_bl_level(struct applespi_data *applespi)
 
 	kfree(efivar_entry);
 
-	return sts ? sts : efi_data;
+	return sts ? sts : efi_data;*/
+	return 1;
 }
 
 static void applespi_save_bl_level(struct applespi_data *applespi,
 				   unsigned int level)
 {
-	efi_guid_t efi_guid;
+	/*efi_guid_t efi_guid;
 	u32 efi_attr;
 	unsigned long efi_data_len;
 	u16 efi_data;
-	int sts;
+	int sts; */
 
-	/* Save keyboard backlight level */
+	/* Save keyboard backlight level */ /*
 	efi_guid = EFI_BL_LEVEL_GUID;
 	efi_data = (u16)level;
 	efi_data_len = sizeof(efi_data);
@@ -1847,7 +1848,7 @@ static void applespi_save_bl_level(struct applespi_data *applespi,
 				    efi_attr, true, efi_data_len, &efi_data);
 	if (sts)
 		dev_warn(&applespi->spi->dev,
-			 "Error saving backlight level to EFI vars: %d\n", sts);
+			 "Error saving backlight level to EFI vars: %d\n", sts);*/
 }
 
 static void applespi_enable_early_event_tracing(struct device *dev)


### PR DESCRIPTION
Here is a mod to allow the driver to compile again for kernel 6.0+ offered in case you want to update